### PR TITLE
feat: add from_raw_unchecked() to Scalar

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -608,7 +608,7 @@ impl Fp {
 
     /// Constructs an element of `Fp` from a little-endian array of limbs without checking that it
     /// is canonical and without converting it to Montgomery form (i.e. without multiplying by `R`).
-    pub fn from_raw_unchecked(l: [u64; 6]) -> Fp {
+    pub const fn from_raw_unchecked(l: [u64; 6]) -> Fp {
         Fp(blst_fp { l })
     }
 

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -364,7 +364,7 @@ impl G1Affine {
         unsafe { Choice::from(blst_p1_affine_on_curve(&self.0) as u8) }
     }
 
-    pub fn from_raw_unchecked(x: Fp, y: Fp, _infinity: bool) -> Self {
+    pub const fn from_raw_unchecked(x: Fp, y: Fp, _infinity: bool) -> Self {
         // FIXME: what about infinity?
         let raw = blst_p1_affine { x: x.0, y: y.0 };
 
@@ -582,7 +582,7 @@ impl G1Projective {
         G1Projective(out)
     }
 
-    pub fn from_raw_unchecked(x: Fp, y: Fp, z: Fp) -> Self {
+    pub const fn from_raw_unchecked(x: Fp, y: Fp, z: Fp) -> Self {
         let raw = blst_p1 {
             x: x.0,
             y: y.0,

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -385,7 +385,7 @@ impl G2Affine {
         unsafe { Choice::from(blst_p2_affine_on_curve(&self.0) as u8) }
     }
 
-    pub fn from_raw_unchecked(x: Fp2, y: Fp2, _infinity: bool) -> Self {
+    pub const fn from_raw_unchecked(x: Fp2, y: Fp2, _infinity: bool) -> Self {
         // FIXME: what about infinity?
         let raw = blst_p2_affine { x: x.0, y: y.0 };
 
@@ -549,7 +549,7 @@ impl G2Projective {
         G2Projective(out)
     }
 
-    pub fn from_raw_unchecked(x: Fp2, y: Fp2, z: Fp2) -> Self {
+    pub const fn from_raw_unchecked(x: Fp2, y: Fp2, z: Fp2) -> Self {
         let raw = blst_p2 {
             x: x.0,
             y: y.0,

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -601,6 +601,13 @@ impl Scalar {
         CtOption::new(Scalar(out), is_some)
     }
 
+    /// Constructs an element of `Scalar` from a little-endian array of limbs without checking
+    /// that it is canonical and without converting it to Montgomery form (i.e. without
+    /// multiplying by `R`).
+    pub const fn from_raw_unchecked(l: [u64; 4]) -> Self {
+        Scalar(blst_fr { l })
+    }
+
     #[allow(clippy::match_like_matches_macro)]
     pub fn is_quad_res(&self) -> Choice {
         match self.legendre() {


### PR DESCRIPTION
Also make all other `from_raw_unchecked()` implementations `const`, so that they can be used when defining constants.